### PR TITLE
Use noRatio instead of applyRatio

### DIFF
--- a/src/mixin/image.js
+++ b/src/mixin/image.js
@@ -13,12 +13,15 @@ export default {
     blur: {
       type: Number,
       required: false
+    },
+    noRatio: {
+      type: Boolean,
+      required: false
     }
   },
 
   data () {
     return {
-      applyRatio: true,
       options: {},
       defaultBlur: 5,
       image: null,
@@ -39,7 +42,7 @@ export default {
     },
 
     wrapperStyle () {
-      if (!this.applyRatio) {
+      if (this.noRatio) {
         return
       }
 


### PR DESCRIPTION
The documentation mentions `no-ratio` to disable the padding applied.

This brings the functionality inline with the documentation.