### PR TITLE
Fix Bug where Placeholder is wider than Main image

### DIFF
--- a/src/component/image.vue
+++ b/src/component/image.vue
@@ -93,7 +93,7 @@
     backface-visibility: hidden;
     transform: translateZ(0) scale(1.1);
     width: 100%;
-    height: auto;
+    height: 100%;
     background-size: cover;
   }
 

--- a/src/component/image.vue
+++ b/src/component/image.vue
@@ -64,8 +64,8 @@
     position: absolute;
     top: 0px;
     left: 0px;
-    width: auto;
-    max-width: 100%;
+    width: 100%;
+    height: auto;
     z-index: 1;
     transition-duration: 1.2s;
     transition-property: all;
@@ -93,7 +93,7 @@
     backface-visibility: hidden;
     transform: translateZ(0) scale(1.1);
     width: 100%;
-    height: 100%;
+    height: auto;
     background-size: cover;
   }
 


### PR DESCRIPTION
The `.progressive-image-placeholder` should have the same size as the `.progressive-image-main` class so that the main image blends nicely on top of the placeholder image.  This bug occurs when the main image is not wide enough to fill its parent container