### PR TITLE
Allow aspect-ratio to be defined as prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ It is possible to remove the padding that adds the aspect ratio to the container
 />
 ```
 
+It is also possible to manually specify the image aspact ratio when you know it. It allows the placeholder to be displayed in the correct aspect ratio. The ratio is calculated as `height / width`.
+
+```html
+<progressive-img
+  src="https://unsplash.it/1920/1080?image=10"
+  aspect-ratio="1.5"
+/>
+```
+
 ## Image fallback
 
 In case of a loading error of the main image, it is possible to add a fallback image which can display an error image or just another image.

--- a/src/mixin/image.js
+++ b/src/mixin/image.js
@@ -13,8 +13,7 @@ export default {
       type: Number
     },
     aspectRatio: {
-      type: Number,
-      default: 0
+      type: Number
     },
     noRatio: {
       type: Boolean
@@ -53,11 +52,8 @@ export default {
       return this.isRendered
     },
 
-    aspectRatioFinal () {
-      if (this.aspectRatio) {
-        return this.aspectRatio
-      }
-      return this.aspectRatioDetect
+    calculatedRatio () {
+      return this.aspectRatio || this.aspectRatioDetect
     },
 
     wrapperStyle () {
@@ -66,7 +62,7 @@ export default {
       }
 
       return {
-        paddingBottom: `${this.aspectRatioFinal * 100}%`
+        paddingBottom: `${this.calculatedRatio * 100}%`
       }
     },
 
@@ -101,10 +97,6 @@ export default {
     },
 
     defineAspectRatio (img) {
-      // if the aspectRatio property was set, we do not need to detect
-      if (this.aspectRatio) {
-        return
-      }
       const delay = this.options.timeout || 2500
       const pollInterval = this.options.pollInterval || 80
 
@@ -139,14 +131,16 @@ export default {
       this.image = null
       this.isRendered = false
 
-      this.defineAspectRatio(image)
+      if (!this.aspectRatio) {
+        this.defineAspectRatio(image)
+      }
 
       image.onload = () => {
         if (this.image) {
           return
         }
 
-        if (this.isPollingKilled) {
+        if (this.isPollingKilled && !this.aspectRatio) {
           this.defineAspectRatio(image)
         }
 

--- a/src/mixin/image.js
+++ b/src/mixin/image.js
@@ -12,6 +12,10 @@ export default {
     blur: {
       type: Number
     },
+    aspectRatio: {
+      type: Number,
+      default: 0
+    },
     noRatio: {
       type: Boolean
     },
@@ -27,7 +31,7 @@ export default {
       defaultBlur: 20,
       image: null,
       placeholderImage: null,
-      aspectRatio: 0.5625,
+      aspectRatioDetect: 0.5625,
       isPollingKilled: false,
       cached: false,
       imageError: false
@@ -49,13 +53,20 @@ export default {
       return this.isRendered
     },
 
+    aspectRatioFinal () {
+      if (this.aspectRatio) {
+        return this.aspectRatio
+      }
+      return this.aspectRatioDetect
+    },
+
     wrapperStyle () {
       if (this.noRatio) {
         return {}
       }
 
       return {
-        paddingBottom: `${this.aspectRatio * 100}%`
+        paddingBottom: `${this.aspectRatioFinal * 100}%`
       }
     },
 
@@ -90,6 +101,10 @@ export default {
     },
 
     defineAspectRatio (img) {
+      // if the aspectRatio property was set, we do not need to detect
+      if (this.aspectRatio) {
+        return
+      }
       const delay = this.options.timeout || 2500
       const pollInterval = this.options.pollInterval || 80
 
@@ -102,7 +117,7 @@ export default {
 
         const { naturalHeight, naturalWidth } = img
 
-        this.aspectRatio = naturalHeight / naturalWidth
+        this.aspectRatioDetect = naturalHeight / naturalWidth
       }, pollInterval)
 
       setTimeout(() => {


### PR DESCRIPTION
Currently the aspect ratio is auto detected for the (main) image. But
the placeholder image will always be displayed with a default aspect
ratio. I assume this is because the placeholder can be an image with
different aspect ratio of the main image.

This change will allow the aspect ratio to be explicitly defined with
a prop. If its not defined, the behavior is as before.