### PR TITLE
Add alt prop and pass through to inner img

### DIFF
--- a/src/component/image.vue
+++ b/src/component/image.vue
@@ -10,6 +10,7 @@
           class="progressive-image-main"
           ref="main"
           :src="image"
+          :alt="alt"
         />
       </transition>
       <transition

--- a/src/mixin/image.js
+++ b/src/mixin/image.js
@@ -20,6 +20,9 @@ export default {
     },
     fallback: {
       type: String
+    },
+    alt: {
+      type: String
     }
   },
 


### PR DESCRIPTION
We're using `vue-progressive-image` in a pattern library project, and it'd be nice to be able to add `alt` attributes to our images.