### PR TITLE
doc : Ajout section Vue CLI et résolution assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,32 @@ Vue.use(VueProgressiveImage, {
 
 **Global options like `placeholder` and `blur` will be applied only to components that don't specify their own options**
 
+# Vue CLI et résolution assets
+
+Si vous souhaitez utiliser dans l'attribut `src` une URL nécessitant d'être résolu sous forme de require par webpack.
+Il faut ajouter les éléments ``et `` au vue-loader.
+
+Pour cela, ajouter à la racine le fichier vue.config.js avec la configuration suivante :
+
+```js
+// vue.config.js
+chainWebpack: (config) => {
+    config.module
+      .rule("vue")
+      .use("vue-loader")
+      .loader("vue-loader")
+      .options({
+        transformAssetUrls: {
+          video: ["src", "poster"],
+          source: "src",
+          img: "src",
+          image: "xlink:href",
+          "progressive-img": "src",
+          "progressive-background": "src",
+        },
+      });
+  },
+```
 
 # Examples
 Check out the `example` folder in the root of the repository for a small vue page with some examples on how to use the plugin.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Vue.use(VueProgressiveImage, {
 # Vue CLI et résolution assets
 
 Si vous souhaitez utiliser dans l'attribut `src` une URL nécessitant d'être résolu sous forme de require par webpack.
-Il faut ajouter les éléments ``et `` au vue-loader.
+Il faut ajouter les éléments `progressive-img` et `progressive-background` au vue-loader.
 
 Pour cela, ajouter à la racine le fichier vue.config.js avec la configuration suivante :
 


### PR DESCRIPTION
Ajout d'une section pour configurer vue-loader sur le projet afin d'utiliser une url `@/asset/...` qui sera ensuite résolu par webpack